### PR TITLE
specify interface for the overlay to use + fixes

### DIFF
--- a/src/common/BaseOverlay.cc
+++ b/src/common/BaseOverlay.cc
@@ -240,10 +240,27 @@ void BaseOverlay::initialize(int stage)
             WATCH(bytesInternalReceived);
         }
 
-        // set up local nodehandle
-        thisNode.setIp(IPvXAddressResolver().
-                      addressOf(getParentModule()->getParentModule()));
-        thisNode.setKey(OverlayKey::UNSPECIFIED_KEY);
+//        // set up local nodehandle
+//        thisNode.setIp(IPvXAddressResolver().
+//                      addressOf(getParentModule()->getParentModule()));
+//        thisNode.setKey(OverlayKey::UNSPECIFIED_KEY);
+//
+        // set up local nodeHandle (optional)
+
+        std::string NodeId = par("nodeHandle").stdstringValue();
+
+        if (NodeId.size()) {
+            // manual configuration of nodeHandle in ini file
+            IPv4Address addr =
+                    IPvXAddressResolver().resolve(NodeId.c_str()).get4();
+            thisNode.setIp(addr);
+            thisNode.setKey(OverlayKey::UNSPECIFIED_KEY);
+        } else {
+            thisNode.setIp(
+                    IPvXAddressResolver().addressOf(
+                            getParentModule()->getParentModule()));
+            thisNode.setKey(OverlayKey::UNSPECIFIED_KEY);
+        }
 
         state = INIT;
         internalReadyState = false;
@@ -612,10 +629,22 @@ void BaseOverlay::join(const OverlayKey& nodeID)
 
     if (state != READY) {
         // set nodeID and IP
-        thisNode.setIp(
-                IPvXAddressResolver().addressOf(getParentModule()->getParentModule()));
+//        thisNode.setIp(
+//                IPvXAddressResolver().addressOf(getParentModule()->getParentModule()));
+        std::string NodeId = par("nodeHandle").stdstringValue();
 
-        if (!nodeID.isUnspecified())  {
+        if (NodeId.size()) {
+            // manual configuration of nodeHandle in ini file
+            IPv4Address addr =
+                    IPvXAddressResolver().resolve(NodeId.c_str()).get4();
+            thisNode.setIp(addr);
+        } else {
+            thisNode.setIp(
+                    IPvXAddressResolver().addressOf(
+                            getParentModule()->getParentModule()));
+        }
+
+        if (!nodeID.isUnspecified()) {
             thisNode.setKey(nodeID);
         } else if (thisNode.getKey().isUnspecified()) {
             std::string nodeIdStr = par("nodeId").stdstringValue();

--- a/src/common/BaseOverlay.cc
+++ b/src/common/BaseOverlay.cc
@@ -241,19 +241,11 @@ void BaseOverlay::initialize(int stage)
         }
 
 //        // set up local nodehandle
-//        thisNode.setIp(IPvXAddressResolver().
-//                      addressOf(getParentModule()->getParentModule()));
-//        thisNode.setKey(OverlayKey::UNSPECIFIED_KEY);
-//
-        // set up local nodeHandle (optional)
-
-        std::string NodeId = par("nodeHandle").stdstringValue();
-
-        if (NodeId.size()) {
-            // manual configuration of nodeHandle in ini file
-            IPv4Address addr =
-                    IPvXAddressResolver().resolve(NodeId.c_str()).get4();
-            thisNode.setIp(addr);
+        const char *interface = par("overlayInterface");
+        if (strcmp(interface, "") != 0) {
+            // manual configuration of overlay interface in INI file
+            thisNode.setIp(IPvXAddressResolver().addressOf(
+                    getParentModule()->getParentModule(), interface));
             thisNode.setKey(OverlayKey::UNSPECIFIED_KEY);
         } else {
             thisNode.setIp(
@@ -629,19 +621,16 @@ void BaseOverlay::join(const OverlayKey& nodeID)
 
     if (state != READY) {
         // set nodeID and IP
-//        thisNode.setIp(
-//                IPvXAddressResolver().addressOf(getParentModule()->getParentModule()));
-        std::string NodeId = par("nodeHandle").stdstringValue();
-
-        if (NodeId.size()) {
-            // manual configuration of nodeHandle in ini file
-            IPv4Address addr =
-                    IPvXAddressResolver().resolve(NodeId.c_str()).get4();
-            thisNode.setIp(addr);
+        const char *interface = par("overlayInterface");
+        if (strcmp(interface, "") != 0) {
+            // manual configuration of overlay interface in INI file
+            thisNode.setIp(IPvXAddressResolver().addressOf(getParentModule()->getParentModule(), interface));
+            thisNode.setKey(OverlayKey::UNSPECIFIED_KEY);
         } else {
             thisNode.setIp(
                     IPvXAddressResolver().addressOf(
                             getParentModule()->getParentModule()));
+            thisNode.setKey(OverlayKey::UNSPECIFIED_KEY);
         }
 
         if (!nodeID.isUnspecified()) {
@@ -1098,8 +1087,15 @@ void BaseOverlay::receiveChangeNotification(int category, const cPolymorphic * d
 void BaseOverlay::handleTransportAddressChangedNotification()
 {
     // get new ip address
-    thisNode.setIp(IPvXAddressResolver().addressOf(
-                      getParentModule()->getParentModule()));
+    const char *interface = par("overlayInterface");
+    if (strcmp(interface, "") != 0) {
+        thisNode.setIp(IPvXAddressResolver().addressOf(
+                getParentModule()->getParentModule(), interface));
+    } else {
+        thisNode.setIp(
+                IPvXAddressResolver().addressOf(
+                        getParentModule()->getParentModule()));
+    }
 
     joinOverlay();
 }

--- a/src/common/BaseOverlay.ned
+++ b/src/common/BaseOverlay.ned
@@ -32,7 +32,8 @@ simple BaseOverlay extends BaseRpc
         int overlayId; // identifies the overlay this node belongs to (used for multiple overlays)
         bool debugOutput; // enable debug output
         int keyLength; // overlay key length in bits
-        string nodeId; // optional nodeId as string in hexadecimal notation 
+        string nodeId; // optional nodeId as string in hexadecimal notation
+        string nodeHandle; // allows to specify which interface a node uses to join the overlay 
         bool useCommonAPIforward; // enable CommonAPI forward() calls
         bool drawOverlayTopology; // draw arrow to successor node?
         int hopCountMax; // maximum number of overlay hops

--- a/src/common/BaseOverlay.ned
+++ b/src/common/BaseOverlay.ned
@@ -33,7 +33,7 @@ simple BaseOverlay extends BaseRpc
         bool debugOutput; // enable debug output
         int keyLength; // overlay key length in bits
         string nodeId; // optional nodeId as string in hexadecimal notation
-        string nodeHandle; // allows to specify which interface a node uses to join the overlay 
+        string overlayInterface = default(""); // allows to specify which interface a node uses to join the overlay 
         bool useCommonAPIforward; // enable CommonAPI forward() calls
         bool drawOverlayTopology; // draw arrow to successor node?
         int hopCountMax; // maximum number of overlay hops

--- a/src/common/GlobalNodeList.cc
+++ b/src/common/GlobalNodeList.cc
@@ -250,9 +250,12 @@ void GlobalNodeList::registerPeer(const NodeHandle& peer,
 {
     PeerHashMap::iterator it = peerStorage.find(peer.getIp());
 
-    if (it == peerStorage.end()) {
-        throw cRuntimeError("GlobalNodeList::registerPeer(): "
-                "Peer is not in peer set");
+    if (it == peerStorage.end()){
+        EV << "GlobalNodeList::registerPeer(): \n"
+                <<"Peer is not in peer set" << endl;
+        return;
+// TODO       throw cRuntimeError("GlobalNodeList::registerPeer(): "
+//                "Peer is not in peer set");
     } else {
         peerStorage.registerOverlay(it, peer, overlayId);
         peerStorage.setBootstrapped(it, overlayId, true);
@@ -530,8 +533,10 @@ std::vector<IPvXAddress>* GlobalNodeList::getAllIps()
 NodeHandle* GlobalNodeList::getNodeHandle(const IPvXAddress& address){
     PeerHashMap::iterator it = peerStorage.find(address);
     if (it == peerStorage.end()) {
-        throw cRuntimeError("GlobalNodeList::getNodeHandle(const IPvXAddress& address): "
-                            "Peer is not in peer set");
+        //TODO
+//        throw cRuntimeError("GlobalNodeList::getNodeHandle(const IPvXAddress& address): "
+//                            "Peer is not in peer set");
+        return 0;
     }
 
     BootstrapEntry* tempEntry = &(it->second);

--- a/src/overlay/chord/Chord.cc
+++ b/src/overlay/chord/Chord.cc
@@ -560,8 +560,8 @@ NodeVector* Chord::findNode(const OverlayKey& key,
         return new NodeVector();
 
     if (successorList->isEmpty() && !predecessorNode.isUnspecified()) {
-        throw new cRuntimeError("Chord: Node is READY, has a "
-                                "predecessor but no successor!");
+// TODO      throw new cRuntimeError("Chord: Node is READY, has a "
+//                                "predecessor but no successor!");
         join();
         return new NodeVector();
     }


### PR DESCRIPTION
Adds a parameter to specify the interface for the overlay to use.
If not specified, it uses the default interface.
Also includes some fixes for OneHop with HNA messages.